### PR TITLE
Ignore patch and minor updates of crate-ci/typos

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "crate-ci/typos"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]


### PR DESCRIPTION
## Summary
- Configure dependabot to ignore patch and minor version updates for `crate-ci/typos`, reducing noise from frequent typo-checker releases that don't require action

## Changes
- Updated `.github/dependabot.yml` to add an `ignore` rule for `crate-ci/typos` covering `version-update:semver-patch` and `version-update:semver-minor` update types

🤖 Generated with [Claude Code](https://claude.com/claude-code)